### PR TITLE
Add GitHub Actions workflow for PyPI releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Publish Release
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install build tools
+        run: python -m pip install --upgrade build twine
+      - name: Build package
+        run: python -m build --sdist --wheel
+      - name: Publish to PyPI
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: python -m twine upload dist/*


### PR DESCRIPTION
Resolves #34

This PR adds a GitHub Actions workflow to automate publishing the chunknorris package to PyPI when new tags matching v*.*.* are pushed.

Steps:
- Checkout code
- Set up Python environment
- Install build and Twine
- Build source and wheel distributions
- Publish to PyPI using PYPI_TOKEN secret
