### PR TITLE
Feature : PDF page classification to decide if page should be embed as image or text

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,18 @@
 .PHONY: black pylint pytest all
 
+isort:
+	isort ./src
+	isort ./tests
+
 black:
-	black --check --verbose ./src
+	black --verbose ./src
+	black --verbose ./tests
 
 pylint:
 	pylint ./src
+	pylint ./tests
 
 pytest:
 	pytest ./tests
 
-all: black pylint pytest
+all: isort black pylint pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ chunknorris = "chunknorris.__main__:main"
 
 [project]
 name = "chunknorris"
-version = "1.3.2"
+version = "1.3.0"
 authors = [{ name = "Wikit", email = "dev@wikit.ai" }]
 description = "A package for chunking documents from various formats"
 keywords = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ chunknorris = "chunknorris.__main__:main"
 
 [project]
 name = "chunknorris"
-version = "1.2.2"
+version = "1.3.2"
 authors = [{ name = "Wikit", email = "dev@wikit.ai" }]
 description = "A package for chunking documents from various formats"
 keywords = [
@@ -51,6 +51,9 @@ dynamic = ["dependencies", "optional-dependencies"]
 [tool.setuptools.dynamic]
 dependencies = { file = ["requirements.txt"] }
 optional-dependencies.dev = { file = ["requirements.dev.txt"] }
+optional-dependencies.ml-onnx = { file = ["requirements.ml-onnx.txt"] }
+optional-dependencies.ml-openvino = { file = ["requirements.ml-openvino.txt"] }
+
 
 [project.urls]
 Homepage = "https://github.com/wikit-ai/chunknorris"

--- a/requirements.ml-onnx.txt
+++ b/requirements.ml-onnx.txt
@@ -1,0 +1,4 @@
+onnxruntime>=1.19
+Pillow
+numpy
+huggingface-hub

--- a/requirements.ml-openvino.txt
+++ b/requirements.ml-openvino.txt
@@ -1,0 +1,4 @@
+openvino>=2026.0
+Pillow
+numpy
+huggingface-hub

--- a/src/chunknorris/__init__.py
+++ b/src/chunknorris/__init__.py
@@ -1,3 +1,4 @@
 from .core.logger import set_log_level
+from .ml import set_ml_backend
 
-__all__ = ["set_log_level"]
+__all__ = ["set_log_level", "set_ml_backend"]

--- a/src/chunknorris/ml/__init__.py
+++ b/src/chunknorris/ml/__init__.py
@@ -1,0 +1,51 @@
+"""ML utilities for chunknorris — global backend configuration.
+
+Usage::
+
+    from chunknorris.ml import set_ml_backend
+    set_ml_backend("openvino")   # validated + dependency-checked immediately
+"""
+
+from __future__ import annotations
+
+_preferred_backend: str = "auto"
+
+
+def set_ml_backend(backend: str) -> None:
+    """Set the preferred ML inference backend for the entire library.
+
+    Validates that the requested backend is installed before storing the
+    preference.  Subsequent calls to ``load_classifier()`` (and
+    ``PdfParser(enable_ml_features=True)``) will use this backend.
+
+    Args:
+        backend: ``"auto"`` (tries OpenVINO first, falls back to ONNX),
+            ``"onnx"``, or ``"openvino"``.
+
+    Raises:
+        ValueError: If *backend* is not a recognised value.
+        ImportError: If the required package for *backend* is not installed.
+
+    Example::
+
+        from chunknorris.ml import set_ml_backend
+        set_ml_backend("openvino")
+    """
+    if backend not in ("auto", "onnx", "openvino"):
+        raise ValueError(
+            f"Unknown backend {backend!r}. Choose 'auto', 'onnx', or 'openvino'."
+        )
+    from .pdf_page_classifiers import check_dependencies
+
+    check_dependencies(backend)
+    global _preferred_backend
+    _preferred_backend = backend
+
+
+def get_ml_backend() -> str:
+    """Return the currently configured ML backend preference.
+
+    Returns:
+        One of ``"auto"``, ``"onnx"``, or ``"openvino"``.
+    """
+    return _preferred_backend

--- a/src/chunknorris/ml/__init__.py
+++ b/src/chunknorris/ml/__init__.py
@@ -6,6 +6,6 @@ Usage::
     set_ml_backend("openvino")   # validated + dependency-checked immediately
 """
 
-from chunknorris.ml._backend import get_ml_backend, set_ml_backend
+from ._backend import get_ml_backend, set_ml_backend
 
 __all__ = ["get_ml_backend", "set_ml_backend"]

--- a/src/chunknorris/ml/__init__.py
+++ b/src/chunknorris/ml/__init__.py
@@ -6,46 +6,6 @@ Usage::
     set_ml_backend("openvino")   # validated + dependency-checked immediately
 """
 
-from __future__ import annotations
+from chunknorris.ml._backend import get_ml_backend, set_ml_backend
 
-_preferred_backend: str = "auto"
-
-
-def set_ml_backend(backend: str) -> None:
-    """Set the preferred ML inference backend for the entire library.
-
-    Validates that the requested backend is installed before storing the
-    preference.  Subsequent calls to ``load_classifier()`` (and
-    ``PdfParser(enable_ml_features=True)``) will use this backend.
-
-    Args:
-        backend: ``"auto"`` (tries OpenVINO first, falls back to ONNX),
-            ``"onnx"``, or ``"openvino"``.
-
-    Raises:
-        ValueError: If *backend* is not a recognised value.
-        ImportError: If the required package for *backend* is not installed.
-
-    Example::
-
-        from chunknorris.ml import set_ml_backend
-        set_ml_backend("openvino")
-    """
-    if backend not in ("auto", "onnx", "openvino"):
-        raise ValueError(
-            f"Unknown backend {backend!r}. Choose 'auto', 'onnx', or 'openvino'."
-        )
-    from .pdf_page_classifiers import check_dependencies
-
-    check_dependencies(backend)
-    global _preferred_backend
-    _preferred_backend = backend
-
-
-def get_ml_backend() -> str:
-    """Return the currently configured ML backend preference.
-
-    Returns:
-        One of ``"auto"``, ``"onnx"``, or ``"openvino"``.
-    """
-    return _preferred_backend
+__all__ = ["get_ml_backend", "set_ml_backend"]

--- a/src/chunknorris/ml/_backend.py
+++ b/src/chunknorris/ml/_backend.py
@@ -5,6 +5,47 @@ from __future__ import annotations
 _preferred_backend: str = "auto"
 
 
+def _is_installed(package: str) -> bool:
+    """Return True if *package* can be imported without error."""
+    try:
+        __import__(package)
+        return True
+    except ImportError:
+        return False
+
+
+def check_dependencies(backend: str = "auto") -> None:
+    """Check that required ML packages are installed for *backend*.
+
+    Args:
+        backend: ``"auto"``, ``"onnx"``, or ``"openvino"``.
+
+    Raises:
+        ImportError: With a install hint if any package is missing.
+    """
+    missing: list[str] = []
+
+    if not _is_installed("huggingface_hub"):
+        missing.append("huggingface-hub  →  pip install huggingface-hub")
+
+    has_onnx = _is_installed("onnxruntime")
+    has_ov = _is_installed("openvino")
+
+    if backend == "onnx" and not has_onnx:
+        missing.append("onnxruntime  →  pip install onnxruntime")
+    elif backend == "openvino" and not has_ov:
+        missing.append("openvino  →  pip install openvino")
+    elif backend == "auto" and not has_onnx and not has_ov:
+        missing.append(
+            "at least one inference backend:\n"
+            "    onnxruntime  →  pip install onnxruntime\n"
+            "    openvino     →  pip install openvino"
+        )
+
+    if missing:
+        raise ImportError("Missing ML dependencies:\n  - " + "\n  - ".join(missing))
+
+
 def set_ml_backend(backend: str) -> None:
     """Set the preferred ML inference backend for the entire library.
 
@@ -29,9 +70,6 @@ def set_ml_backend(backend: str) -> None:
         raise ValueError(
             f"Unknown backend {backend!r}. Choose 'auto', 'onnx', or 'openvino'."
         )
-    # pylint: disable=import-outside-toplevel
-    from .pdf_page_classifiers import check_dependencies
-
     check_dependencies(backend)
     global _preferred_backend
     _preferred_backend = backend

--- a/src/chunknorris/ml/_backend.py
+++ b/src/chunknorris/ml/_backend.py
@@ -1,0 +1,46 @@
+"""Global ML backend configuration state for chunknorris."""
+
+from __future__ import annotations
+
+_preferred_backend: str = "auto"
+
+
+def set_ml_backend(backend: str) -> None:
+    """Set the preferred ML inference backend for the entire library.
+
+    Validates that the requested backend is installed before storing the
+    preference.  Subsequent calls to ``load_classifier()`` (and
+    ``PdfParser(enable_ml_features=True)``) will use this backend.
+
+    Args:
+        backend: ``"auto"`` (tries OpenVINO first, falls back to ONNX),
+            ``"onnx"``, or ``"openvino"``.
+
+    Raises:
+        ValueError: If *backend* is not a recognised value.
+        ImportError: If the required package for *backend* is not installed.
+
+    Example::
+
+        from chunknorris.ml import set_ml_backend
+        set_ml_backend("openvino")
+    """
+    if backend not in ("auto", "onnx", "openvino"):
+        raise ValueError(
+            f"Unknown backend {backend!r}. Choose 'auto', 'onnx', or 'openvino'."
+        )
+    # pylint: disable=import-outside-toplevel
+    from chunknorris.ml.pdf_page_classifiers import check_dependencies
+
+    check_dependencies(backend)
+    global _preferred_backend
+    _preferred_backend = backend
+
+
+def get_ml_backend() -> str:
+    """Return the currently configured ML backend preference.
+
+    Returns:
+        One of ``"auto"``, ``"onnx"``, or ``"openvino"``.
+    """
+    return _preferred_backend

--- a/src/chunknorris/ml/_backend.py
+++ b/src/chunknorris/ml/_backend.py
@@ -30,7 +30,7 @@ def set_ml_backend(backend: str) -> None:
             f"Unknown backend {backend!r}. Choose 'auto', 'onnx', or 'openvino'."
         )
     # pylint: disable=import-outside-toplevel
-    from chunknorris.ml.pdf_page_classifiers import check_dependencies
+    from .pdf_page_classifiers import check_dependencies
 
     check_dependencies(backend)
     global _preferred_backend

--- a/src/chunknorris/ml/pdf_page_classifiers/__init__.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/__init__.py
@@ -1,0 +1,174 @@
+"""PDF page classifier — public factory with HuggingFace auto-download.
+
+Local usage (directory with model files)::
+
+    from chunknorris.ml.pdf_page_classifiers import load_classifier
+    clf = load_classifier("path/to/model/dir")
+    result = clf.predict("page.png")
+
+HuggingFace usage (auto-download on first call, then cached)::
+
+    from chunknorris.ml.pdf_page_classifiers import load_classifier
+    clf = load_classifier()          # uses default Wikit repo
+    result = clf.predict("page.png")
+    print(result.needs_image_embedding, result.predicted_classes)
+
+The downloaded model files are stored in the standard HuggingFace cache
+(``~/.cache/huggingface/hub/``).  Set the ``HF_HOME`` or
+``HUGGINGFACE_HUB_CACHE`` environment variable to customise the location.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any
+
+# Fixed HuggingFace repository — updated by Wikit when new model versions ship.
+_DEFAULT_REPO_ID = "Wikit/pdf-pages-classifier"
+
+
+# ---------------------------------------------------------------------------
+# Dependency checking
+# ---------------------------------------------------------------------------
+
+
+def check_dependencies(backend: str = "auto") -> None:
+    """Check that required ML packages are installed for *backend*.
+
+    Args:
+        backend: ``"auto"``, ``"onnx"``, or ``"openvino"``.
+
+    Raises:
+        ImportError: With a install hint if any package is missing.
+    """
+    missing: list[str] = []
+
+    if not _is_installed("huggingface_hub"):
+        missing.append("huggingface-hub  →  pip install huggingface-hub")
+
+    has_onnx = _is_installed("onnxruntime")
+    has_ov = _is_installed("openvino")
+
+    if backend == "onnx" and not has_onnx:
+        missing.append("onnxruntime  →  pip install onnxruntime")
+    elif backend == "openvino" and not has_ov:
+        missing.append("openvino  →  pip install openvino")
+    elif backend == "auto" and not has_onnx and not has_ov:
+        missing.append(
+            "at least one inference backend:\n"
+            "    onnxruntime  →  pip install onnxruntime\n"
+            "    openvino     →  pip install openvino"
+        )
+
+    if missing:
+        raise ImportError("Missing ML dependencies:\n  - " + "\n  - ".join(missing))
+
+
+def _is_installed(package: str) -> bool:
+    """Return True if *package* can be imported without error."""
+    try:
+        __import__(package)
+        return True
+    except ImportError:
+        return False
+
+
+def _is_hf_repo_id(path: str) -> bool:
+    """Return True if *path* looks like ``'owner/repo'`` rather than a local path."""
+    if os.path.exists(path):
+        return False
+    normalized = path.replace("\\", "/")
+    if normalized.startswith((".", "/", "~")):
+        return False
+    parts = normalized.split("/")
+    return len(parts) == 2 and all(p.strip() for p in parts)
+
+
+# ---------------------------------------------------------------------------
+# Public factory
+# ---------------------------------------------------------------------------
+
+
+def load_classifier(
+    repo_or_dir: str = _DEFAULT_REPO_ID,
+    backend: str | None = None,
+    device: str = "CPU",
+) -> Any:
+    """Load a PDF page classifier.
+
+    Args:
+        repo_or_dir: HuggingFace repo ID or local directory containing
+            ``config.json`` and model files.  Defaults to the official Wikit
+            repo (``"Wikit/pdf-pages-classifier"``).
+        backend: ``"auto"`` tries OpenVINO first, falls back to ONNX.
+            Pass ``"openvino"`` or ``"onnx"`` to force a specific backend.
+            ``None`` defers to the library-wide preference set via
+            :func:`chunknorris.ml.set_ml_backend` (default ``"auto"``).
+        device: OpenVINO device string (``"CPU"``, ``"GPU"``, ``"AUTO"``).
+            Ignored for the ONNX backend.
+
+    Returns:
+        A classifier instance exposing ``predict(images)``.
+
+    Example::
+
+        clf = load_classifier()
+        result = clf.predict("page.png")
+        print(result["needs_image_embedding"], result["predicted_classes"])
+    """
+    if backend is None:
+        from chunknorris.ml import get_ml_backend
+
+        backend = get_ml_backend()
+
+    if backend not in ("auto", "onnx", "openvino"):
+        raise ValueError(
+            f"Unknown backend {backend!r}. Choose 'auto', 'onnx', or 'openvino'."
+        )
+
+    check_dependencies(backend)
+
+    is_hf = _is_hf_repo_id(repo_or_dir)
+
+    if backend in ("auto", "openvino"):
+        try:
+            return _load_openvino(repo_or_dir, device=device, is_hf=is_hf)
+        except (ImportError, FileNotFoundError):
+            if backend == "openvino":
+                raise
+
+    return _load_onnx(repo_or_dir, is_hf=is_hf)
+
+
+# ---------------------------------------------------------------------------
+# Backend-specific loaders
+# ---------------------------------------------------------------------------
+
+
+def _load_onnx(repo_or_dir: str, is_hf: bool) -> Any:
+    from .classifier_onnx import PDFPageClassifierONNX
+    from .hf_utils import (
+        _ONNX_FP32_FILES,
+        _ONNX_INT8_FILES,
+        _download_with_int8_fallback,
+    )
+
+    model_dir = (
+        _download_with_int8_fallback(repo_or_dir, _ONNX_INT8_FILES, _ONNX_FP32_FILES)
+        if is_hf
+        else Path(repo_or_dir)
+    )
+    return PDFPageClassifierONNX.from_pretrained(str(model_dir))
+
+
+def _load_openvino(repo_or_dir: str, device: str, is_hf: bool) -> Any:
+    from .classifier_ov import PDFPageClassifierOV
+    from .hf_utils import _OV_FP32_FILES, _OV_INT8_FILES, _download_with_int8_fallback
+
+    model_dir = (
+        _download_with_int8_fallback(repo_or_dir, _OV_INT8_FILES, _OV_FP32_FILES)
+        if is_hf
+        else Path(repo_or_dir)
+    )
+    return PDFPageClassifierOV.from_pretrained(str(model_dir), device=device)

--- a/src/chunknorris/ml/pdf_page_classifiers/__init__.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/__init__.py
@@ -118,7 +118,8 @@ def load_classifier(
         print(result["needs_image_embedding"], result["predicted_classes"])
     """
     if backend is None:
-        from chunknorris.ml import get_ml_backend
+        # pylint: disable=import-outside-toplevel
+        from chunknorris.ml._backend import get_ml_backend
 
         backend = get_ml_backend()
 
@@ -147,8 +148,9 @@ def load_classifier(
 
 
 def _load_onnx(repo_or_dir: str, is_hf: bool) -> Any:
+    # pylint: disable=import-outside-toplevel
     from .classifier_onnx import PDFPageClassifierONNX
-    from .hf_utils import (
+    from .hf_utils import (  # pylint: disable=import-outside-toplevel
         _ONNX_FP32_FILES,
         _ONNX_INT8_FILES,
         _download_with_int8_fallback,
@@ -163,8 +165,13 @@ def _load_onnx(repo_or_dir: str, is_hf: bool) -> Any:
 
 
 def _load_openvino(repo_or_dir: str, device: str, is_hf: bool) -> Any:
+    # pylint: disable=import-outside-toplevel
     from .classifier_ov import PDFPageClassifierOV
-    from .hf_utils import _OV_FP32_FILES, _OV_INT8_FILES, _download_with_int8_fallback
+    from .hf_utils import (  # pylint: disable=import-outside-toplevel
+        _OV_FP32_FILES,
+        _OV_INT8_FILES,
+        _download_with_int8_fallback,
+    )
 
     model_dir = (
         _download_with_int8_fallback(repo_or_dir, _OV_INT8_FILES, _OV_FP32_FILES)

--- a/src/chunknorris/ml/pdf_page_classifiers/__init__.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/__init__.py
@@ -24,54 +24,10 @@ import os
 from pathlib import Path
 from typing import Any
 
+from chunknorris.ml._backend import check_dependencies, get_ml_backend
+
 # Fixed HuggingFace repository — updated by Wikit when new model versions ship.
 _DEFAULT_REPO_ID = "Wikit/pdf-pages-classifier"
-
-
-# ---------------------------------------------------------------------------
-# Dependency checking
-# ---------------------------------------------------------------------------
-
-
-def check_dependencies(backend: str = "auto") -> None:
-    """Check that required ML packages are installed for *backend*.
-
-    Args:
-        backend: ``"auto"``, ``"onnx"``, or ``"openvino"``.
-
-    Raises:
-        ImportError: With a install hint if any package is missing.
-    """
-    missing: list[str] = []
-
-    if not _is_installed("huggingface_hub"):
-        missing.append("huggingface-hub  →  pip install huggingface-hub")
-
-    has_onnx = _is_installed("onnxruntime")
-    has_ov = _is_installed("openvino")
-
-    if backend == "onnx" and not has_onnx:
-        missing.append("onnxruntime  →  pip install onnxruntime")
-    elif backend == "openvino" and not has_ov:
-        missing.append("openvino  →  pip install openvino")
-    elif backend == "auto" and not has_onnx and not has_ov:
-        missing.append(
-            "at least one inference backend:\n"
-            "    onnxruntime  →  pip install onnxruntime\n"
-            "    openvino     →  pip install openvino"
-        )
-
-    if missing:
-        raise ImportError("Missing ML dependencies:\n  - " + "\n  - ".join(missing))
-
-
-def _is_installed(package: str) -> bool:
-    """Return True if *package* can be imported without error."""
-    try:
-        __import__(package)
-        return True
-    except ImportError:
-        return False
 
 
 def _is_hf_repo_id(path: str) -> bool:
@@ -118,9 +74,6 @@ def load_classifier(
         print(result["needs_image_embedding"], result["predicted_classes"])
     """
     if backend is None:
-        # pylint: disable=import-outside-toplevel
-        from chunknorris.ml._backend import get_ml_backend
-
         backend = get_ml_backend()
 
     if backend not in ("auto", "onnx", "openvino"):

--- a/src/chunknorris/ml/pdf_page_classifiers/base_classifier.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/base_classifier.py
@@ -1,0 +1,224 @@
+from abc import abstractmethod, ABC
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any, Literal
+
+from PIL import Image
+import numpy as np
+import numpy.typing as npt
+
+from .types import PdfPagePrediction
+
+
+class _BasePDFPageClassifier(ABC):  # type: ignore[reportUnusedClass]
+    """Shared preprocessing, formatting, and predict logic.
+
+    Subclasses must implement ``_run_batch`` to perform backend-specific
+    inference on a (N, C, H, W) float32 numpy array.
+    """
+
+    def __init__(self, config: dict[str, Any]) -> None:
+        self._image_size: int = config["image_size"]
+        self._mean = np.array(config["mean"], dtype=np.float32)
+        self._std = np.array(config["std"], dtype=np.float32)
+        self._center_crop: bool = config.get("center_crop_shortest", True)
+        self._whiteout: bool = config.get("whiteout_header", False)
+        self._whiteout_cutoff: int = int(
+            self._image_size * config.get("whiteout_fraction", 0.15)
+        )
+        self._class_names: list[str] = config["class_names"]
+        self._threshold: float = float(config.get("threshold", 0.5))
+        self._image_required_classes: set[str] = set(
+            config.get("image_required_classes", [])
+        )
+        self._precision: str = ""
+
+    @property
+    @abstractmethod
+    def backend(self) -> Literal["onnx", "openvino"]:
+        """Backend used for inference."""
+
+    @property
+    def friendly_name(self) -> str:
+        return "PDF pages classifier"
+
+    @property
+    def precision(self) -> Literal["int8", "fp32"]:
+        """Precision of the loaded model."""
+        return self._precision
+
+    @property
+    def variant(self) -> str:
+        """Human-readable variant string, e.g. ``'onnx/int8'`` or ``'openvino/fp32'``."""
+        return f"{self.friendly_name}, {self.backend}/{self.precision}"
+
+    def __repr__(self) -> str:
+        return f"{self.__class__.__name__}(variant={self.variant!r})"
+
+    @abstractmethod
+    def _run_batch(
+        self, batch_input: npt.NDArray[np.float32]
+    ) -> npt.NDArray[np.float32]:
+        """Run inference on a (N, C, H, W) float32 batch.
+
+        Returns:
+            (N, num_classes) float32 array of probabilities.
+        """
+
+    @staticmethod
+    def _load_image(item: str | Image.Image) -> Image.Image:
+        """Load an image from a file path or PIL image and convert to RGB.
+
+        Args:
+            item: File path string or PIL image (any mode).
+
+        Returns:
+            RGB PIL image.
+
+        Raises:
+            TypeError: If ``item`` is neither a str nor a PIL.Image.
+        """
+        if isinstance(item, str):
+            return Image.open(item).convert("RGB")
+        return item.convert("RGB")
+
+    def _pil_to_array(self, img: Image.Image) -> npt.NDArray[np.float32]:
+        """Apply spatial transforms and return a (H, W, C) float32 array in [0, 1].
+
+        Normalization and the channel transpose are intentionally deferred so
+        they can be applied in a single vectorised pass over the whole batch in
+        ``_normalize_batch``.
+
+        Steps:
+          1. Center-crop to square (shortest side), if enabled.
+          2. Resize to (image_size, image_size) with bicubic interpolation.
+          3. Scale pixel values to [0, 1].
+          4. White out top header rows, if enabled.
+
+        Args:
+            img: RGB PIL image.
+
+        Returns:
+            Float32 array of shape (image_size, image_size, 3).
+        """
+        if self._center_crop:
+            w, h = img.size
+            sq = min(w, h)
+            img = img.crop(((w - sq) // 2, (h - sq) // 2, (w + sq) // 2, (h + sq) // 2))
+
+        img = img.resize((self._image_size, self._image_size), Image.Resampling.BICUBIC)
+        arr = np.asarray(img, dtype=np.float32) * (1.0 / 255.0)  # (H, W, C)
+
+        if self._whiteout:
+            arr[: self._whiteout_cutoff] = 1.0
+
+        return arr
+
+    def _normalize_batch(
+        self, arrays: list[npt.NDArray[np.float32]]
+    ) -> npt.NDArray[np.float32]:
+        """Stack a list of (H, W, C) arrays and apply ImageNet normalization.
+
+        Args:
+            arrays: List of float32 arrays, each of shape (H, W, C) in [0, 1].
+
+        Returns:
+            Float32 array of shape (N, C, H, W), normalized with ImageNet stats.
+        """
+        batch = np.stack(arrays, axis=0)  # (N, H, W, C)
+        batch = (batch - self._mean) / self._std  # broadcast over (H, W, C)
+        return batch.transpose(0, 3, 1, 2)  # (N, C, H, W)
+
+    def _format(
+        self,
+        probabilities: npt.NDArray[np.float32],
+        threshold: float,
+    ) -> PdfPagePrediction:
+        """Format model output probabilities into a prediction object.
+
+        Args:
+            probabilities: 1-D float32 array of per-class probabilities.
+            threshold: Probability cutoff for a positive prediction.
+
+        Returns:
+            A ``PdfPagePrediction`` instance.
+        """
+        predicted_classes = [
+            name
+            for name, prob in zip(self._class_names, probabilities)
+            if prob >= threshold
+        ]
+        return PdfPagePrediction(
+            needs_image_embedding=any(
+                c in self._image_required_classes for c in predicted_classes
+            ),
+            predicted_classes=predicted_classes,
+            probabilities={
+                name: float(prob)
+                for name, prob in zip(self._class_names, probabilities)
+            },
+        )
+
+    def predict(
+        self,
+        images: str | Image.Image | list[Any],
+        threshold: float | None = None,
+        batch_size: int = 32,
+        num_workers: int = 4,
+    ) -> PdfPagePrediction | list[PdfPagePrediction]:
+        """Classify one or more PDF page images.
+
+        Args:
+            images: A single image (file path string or PIL.Image) or a list
+                of images.
+            threshold: Override the default probability threshold from config.
+                The override is local to this call and does not mutate the
+                classifier instance.
+            batch_size: Number of images to process per inference call.
+            num_workers: Number of threads for parallel image loading and
+                preprocessing. Set to 1 to disable threading.
+
+        Returns:
+            A single ``PdfPagePrediction`` when ``images`` is not a list, or a
+            list of ``PdfPagePrediction`` otherwise.
+        """
+        effective_threshold = self._threshold if threshold is None else threshold
+
+        is_single = not isinstance(images, list)
+        image_list: list[Any] = [images] if is_single else images
+
+        all_results: list[PdfPagePrediction] = []
+
+        with ThreadPoolExecutor(max_workers=num_workers) as executor:
+            for batch_start in range(0, len(image_list), batch_size):
+                batch_items = image_list[batch_start : batch_start + batch_size]
+
+                # Load (file I/O + RGB conversion) in parallel, then free after use.
+                loaded: list[Image.Image] = list(
+                    executor.map(self._load_image, batch_items)
+                )
+                # PIL transforms (crop + bicubic resize) in parallel.
+                arrays: list[npt.NDArray[np.float32]] = list(
+                    executor.map(self._pil_to_array, loaded)
+                )
+
+                # Vectorised normalization + transpose, then inference.
+                batch_input = self._normalize_batch(arrays)  # (N, C, H, W)
+                probs_batch: npt.NDArray[np.float32] = self._run_batch(batch_input)
+
+                all_results.extend(
+                    self._format(probs, effective_threshold) for probs in probs_batch
+                )
+
+        return all_results[0] if is_single else all_results
+
+    def __call__(
+        self,
+        images: str | Image.Image | list[Any],
+        threshold: float | None = None,
+        batch_size: int = 32,
+        num_workers: int = 4,
+    ) -> PdfPagePrediction | list[PdfPagePrediction]:
+        """Delegate to predict(). See predict() for full documentation."""
+        return self.predict(
+            images, threshold=threshold, batch_size=batch_size, num_workers=num_workers
+        )

--- a/src/chunknorris/ml/pdf_page_classifiers/base_classifier.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/base_classifier.py
@@ -1,10 +1,10 @@
-from abc import abstractmethod, ABC
+from abc import ABC, abstractmethod
 from concurrent.futures import ThreadPoolExecutor
 from typing import Any, Literal
 
-from PIL import Image
 import numpy as np
 import numpy.typing as npt
+from PIL import Image
 
 from .types import PdfPagePrediction
 

--- a/src/chunknorris/ml/pdf_page_classifiers/classifier_onnx.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/classifier_onnx.py
@@ -1,0 +1,99 @@
+"""PDF page classifier for production inference."""
+
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+
+from .base_classifier import _BasePDFPageClassifier
+from ...core.logger import LOGGER
+
+try:
+    import onnxruntime as ort
+except ImportError as _e:
+    raise ImportError(
+        "onnxruntime is required for inference.\n"
+        "Install with: pip install onnxruntime"
+    ) from _e
+
+
+class PDFPageClassifierONNX(_BasePDFPageClassifier):
+    """Classify PDF pages using a deployed ONNX model.
+
+    Loads a self-contained deployment directory produced by
+    ``export_onnx.save_for_deployment`` and exposes a simple ``predict``
+    interface.  All preprocessing (center-crop, resize, normalization) is
+    performed in pure PIL + numpy, matching the pipeline used during training.
+
+    Example::
+
+        clf = PDFPageClassifier.from_pretrained("outputs/run-42/deployment")
+        result = clf.predict("page_001.png")
+        print(result.needs_image_embedding, result.predicted_classes)
+    """
+
+    def __init__(self, model_path: str, config: dict[str, Any]) -> None:
+        """Initialise the classifier.
+
+        Args:
+            model_path: Path to the ONNX model file.
+            config: Deployment config dict (same schema as config.json written
+                by save_for_deployment).
+        """
+        super().__init__(config)
+        self._session = ort.InferenceSession(model_path)  # type: ignore[unknownMemberType]
+        self._input_name: str = self._session.get_inputs()[0].name  # type: ignore[unknownMemberType]
+
+    @property
+    def backend(self) -> Literal["onnx"]:
+        """Backend used for inference."""
+        return "onnx"
+
+    @classmethod
+    def from_pretrained(cls, model_dir: str) -> PDFPageClassifierONNX:
+        """Load a classifier from a deployment directory.
+
+        The directory must contain:
+          - ``model.onnx``  — exported by save_for_deployment
+          - ``config.json`` — written by save_for_deployment
+
+        Args:
+            model_dir: Path to the deployment directory.
+
+        Returns:
+            Initialised PDFPageClassifier.
+        """
+        path = Path(model_dir)
+        config_path = path / "config.json"
+
+        if not config_path.exists():
+            raise FileNotFoundError(f"config.json not found in {model_dir}")
+
+        # Prefer INT8 (QAT export) over FP32 when both are present
+        candidates = ["model_int8.onnx", "model.onnx"]
+        for candidate in candidates:
+            if (path / candidate).exists():
+                model_path = path / candidate
+                break
+        else:
+            raise FileNotFoundError(
+                f"No ONNX model found in {model_dir}. "
+                f"Expected one of: {', '.join(candidates)}."
+            )
+
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+
+        instance = cls(str(model_path), config)
+        instance._precision = "int8" if "int8" in model_path.name else "fp32"
+        LOGGER.info("Loaded model : %s", instance.variant)
+
+        return instance
+
+    def _run_batch(
+        self, batch_input: npt.NDArray[np.float32]
+    ) -> npt.NDArray[np.float32]:
+        return self._session.run(None, {self._input_name: batch_input})[0]  # type: ignore[unknownMemberType]

--- a/src/chunknorris/ml/pdf_page_classifiers/classifier_onnx.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/classifier_onnx.py
@@ -1,6 +1,7 @@
 """PDF page classifier for production inference."""
 
 from __future__ import annotations
+
 import json
 from pathlib import Path
 from typing import Any, Literal
@@ -8,8 +9,8 @@ from typing import Any, Literal
 import numpy as np
 import numpy.typing as npt
 
-from .base_classifier import _BasePDFPageClassifier
 from ...core.logger import LOGGER
+from .base_classifier import _BasePDFPageClassifier
 
 try:
     import onnxruntime as ort

--- a/src/chunknorris/ml/pdf_page_classifiers/classifier_onnx.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/classifier_onnx.py
@@ -58,8 +58,8 @@ class PDFPageClassifierONNX(_BasePDFPageClassifier):
         """Load a classifier from a deployment directory.
 
         The directory must contain:
-          - ``model.onnx``  — exported by save_for_deployment
-          - ``config.json`` — written by save_for_deployment
+          - ``model.onnx``
+          - ``config.json``
 
         Args:
             model_dir: Path to the deployment directory.

--- a/src/chunknorris/ml/pdf_page_classifiers/classifier_ov.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/classifier_ov.py
@@ -1,0 +1,124 @@
+"""OpenVINO-based PDF page classifier for production inference."""
+
+from __future__ import annotations
+import json
+from pathlib import Path
+from typing import Any, Literal
+
+import numpy as np
+import numpy.typing as npt
+
+try:
+    from openvino import Core
+    from openvino import CompiledModel
+except ImportError as _e:
+    raise ImportError(
+        "openvino is required for OpenVINO inference.\n"
+        "Install with: pip install openvino"
+    ) from _e
+
+from .base_classifier import _BasePDFPageClassifier
+from ...core.logger import LOGGER
+
+
+class PDFPageClassifierOV(_BasePDFPageClassifier):
+    """Classify PDF pages using a deployed OpenVINO IR model.
+
+    Loads a self-contained deployment directory produced by
+    ``export_onnx.save_for_deployment`` (with ``export_openvino=True``) and
+    exposes the same ``predict`` interface as ``PDFPageClassifier``.
+
+    Automatically selects the INT8 variant (``model_ov_int8.xml``) when it
+    exists alongside the FP32 model, falling back to ``model_ov.xml``.
+
+    Example::
+
+        clf = PDFPageClassifierOV.from_pretrained("outputs/run-42/deployment")
+        result = clf.predict("page_001.png")
+        print(result.needs_image_embedding, result.predicted_classes)
+    """
+
+    def __init__(
+        self,
+        model_path: str,
+        config: dict[str, Any],
+        device: str = "CPU",
+    ) -> None:
+        """Initialise the classifier.
+
+        Args:
+            model_path: Path to the OpenVINO IR ``.xml`` file.
+            config: Deployment config dict (same schema as config.json written
+                by save_for_deployment).
+            device: OpenVINO device string (``"CPU"``, ``"GPU"``, ``"AUTO"``).
+        """
+        super().__init__(config)
+        compiled: CompiledModel = Core().compile_model(model_path, device)
+        self._session: CompiledModel = compiled
+        self._input_name: str = compiled.input(0).get_any_name()
+        self._output = compiled.output(0)
+
+    @property
+    def backend(self) -> Literal["openvino"]:
+        """Backend used for inference."""
+        return "openvino"
+
+    @classmethod
+    def from_pretrained(
+        cls,
+        model_dir: str,
+        device: str = "CPU",
+    ) -> PDFPageClassifierOV:
+        """Load a classifier from a deployment directory.
+
+        The directory must contain:
+          - ``model_ov.xml`` / ``model_ov_int8.xml`` — exported by
+            save_for_deployment with ``export_openvino=True``
+          - ``config.json`` — written by save_for_deployment
+
+        The INT8 model (``model_ov_int8.xml``) is preferred when present.
+
+        Args:
+            model_dir: Path to the deployment directory.
+            device: OpenVINO device string (``"CPU"``, ``"GPU"``, ``"AUTO"``).
+
+        Returns:
+            Initialised PDFPageClassifierOV.
+        """
+        path = Path(model_dir)
+        config_path = path / "config.json"
+
+        if not config_path.exists():
+            raise FileNotFoundError(f"config.json not found in {model_dir}")
+
+        # Search order: prefer INT8 over FP32, HF/Optimum names over legacy names
+        candidates = [
+            "openvino_model_int8.xml",  # HF-style INT8 (preferred)
+            "openvino_model.xml",  # HF-style FP32
+            "model_ov_int8.xml",  # legacy local INT8
+            "model_ov.xml",  # legacy local FP32
+        ]
+        for candidate in candidates:
+            if (path / candidate).exists():
+                model_path = path / candidate
+                break
+        else:
+            raise FileNotFoundError(
+                f"No OpenVINO model found in {model_dir}. "
+                f"Expected one of: {', '.join(candidates)}. "
+                "Export with save_for_deployment(..., export_openvino=True)."
+            )
+
+        with open(config_path, encoding="utf-8") as f:
+            config = json.load(f)
+
+        instance = cls(str(model_path), config, device=device)
+        instance._precision = "int8" if "int8" in model_path.name else "fp32"
+        LOGGER.info("Loaded model : %s", instance.variant)
+
+        return instance
+
+    def _run_batch(
+        self, batch_input: npt.NDArray[np.float32]
+    ) -> npt.NDArray[np.float32]:
+        return self._session({self._input_name: batch_input})[self._output]

--- a/src/chunknorris/ml/pdf_page_classifiers/classifier_ov.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/classifier_ov.py
@@ -53,10 +53,10 @@ class PDFPageClassifierOV(_BasePDFPageClassifier):
             device: OpenVINO device string (``"CPU"``, ``"GPU"``, ``"AUTO"``).
         """
         super().__init__(config)
-        compiled: CompiledModel = Core().compile_model(model_path, device)
+        compiled: CompiledModel = Core().compile_model(model_path, device)  # type: ignore
         self._session: CompiledModel = compiled
-        self._input_name: str = compiled.input(0).get_any_name()
-        self._output = compiled.output(0)
+        self._input_name: str = compiled.input(0).get_any_name()  # type: ignore
+        self._output = compiled.output(0)  # type: ignore
 
     @property
     def backend(self) -> Literal["openvino"]:
@@ -91,12 +91,10 @@ class PDFPageClassifierOV(_BasePDFPageClassifier):
         if not config_path.exists():
             raise FileNotFoundError(f"config.json not found in {model_dir}")
 
-        # Search order: prefer INT8 over FP32, HF/Optimum names over legacy names
+        # Search order: prefer INT8 over FP32, HF/Optimum names
         candidates = [
-            "openvino_model_int8.xml",  # HF-style INT8 (preferred)
-            "openvino_model.xml",  # HF-style FP32
-            "model_ov_int8.xml",  # legacy local INT8
-            "model_ov.xml",  # legacy local FP32
+            "openvino_model_int8.xml",
+            "openvino_model.xml",
         ]
         for candidate in candidates:
             if (path / candidate).exists():
@@ -121,4 +119,4 @@ class PDFPageClassifierOV(_BasePDFPageClassifier):
     def _run_batch(
         self, batch_input: npt.NDArray[np.float32]
     ) -> npt.NDArray[np.float32]:
-        return self._session({self._input_name: batch_input})[self._output]
+        return self._session({self._input_name: batch_input})[self._output]  # type: ignore

--- a/src/chunknorris/ml/pdf_page_classifiers/classifier_ov.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/classifier_ov.py
@@ -1,6 +1,7 @@
 """OpenVINO-based PDF page classifier for production inference."""
 
 from __future__ import annotations
+
 import json
 from pathlib import Path
 from typing import Any, Literal
@@ -9,16 +10,15 @@ import numpy as np
 import numpy.typing as npt
 
 try:
-    from openvino import Core
-    from openvino import CompiledModel
+    from openvino import CompiledModel, Core
 except ImportError as _e:
     raise ImportError(
         "openvino is required for OpenVINO inference.\n"
         "Install with: pip install openvino"
     ) from _e
 
-from .base_classifier import _BasePDFPageClassifier
 from ...core.logger import LOGGER
+from .base_classifier import _BasePDFPageClassifier
 
 
 class PDFPageClassifierOV(_BasePDFPageClassifier):

--- a/src/chunknorris/ml/pdf_page_classifiers/hf_utils.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/hf_utils.py
@@ -1,0 +1,51 @@
+"""HuggingFace download utilities for PDF page classifiers.
+
+This module is imported lazily (after dependency checks pass), so the
+top-level huggingface_hub imports are safe.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from huggingface_hub import hf_hub_download
+from huggingface_hub.errors import EntryNotFoundError
+
+# INT8 preferred over FP32 for both backends — faster and smaller.
+_ONNX_INT8_FILES = ["model_int8.onnx", "config.json"]
+_ONNX_FP32_FILES = ["model.onnx", "config.json"]
+
+_OV_INT8_FILES = [
+    "openvino_model_int8.xml",
+    "openvino_model_int8.bin",
+    "config.json",
+]
+_OV_FP32_FILES = ["openvino_model.xml", "openvino_model.bin", "config.json"]
+
+
+def _download_from_hf(repo_id: str, filenames: list[str]) -> Path:
+    """Download *filenames* from *repo_id* and return the local snapshot directory.
+
+    Files land in the standard HuggingFace cache
+    (``~/.cache/huggingface/hub/``).  The cache location can be overridden
+    via the ``HF_HOME`` or ``HUGGINGFACE_HUB_CACHE`` environment variables.
+    """
+    last: Path | None = None
+    for filename in filenames:
+        last = Path(hf_hub_download(repo_id=repo_id, filename=filename))
+
+    if last is None:
+        raise ValueError("filenames must not be empty")
+    return last.parent
+
+
+def _download_with_int8_fallback(  # type: ignore[reportUnusedFunction]
+    repo_id: str,
+    int8_files: list[str],
+    fp32_files: list[str],
+) -> Path:
+    """Download from HF, preferring INT8 over FP32 when available."""
+    try:
+        return _download_from_hf(repo_id, int8_files)
+    except EntryNotFoundError:
+        return _download_from_hf(repo_id, fp32_files)

--- a/src/chunknorris/ml/pdf_page_classifiers/types.py
+++ b/src/chunknorris/ml/pdf_page_classifiers/types.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+
+
+class PdfPagePrediction(BaseModel):
+    needs_image_embedding: bool
+    predicted_classes: list[str]
+    probabilities: dict[str, float]

--- a/src/chunknorris/parsers/docx/docx_parser.py
+++ b/src/chunknorris/parsers/docx/docx_parser.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import html
+from pathlib import Path
 
 import mammoth  # type: ignore : No stub files
 

--- a/src/chunknorris/parsers/markdown/markdown_parser.py
+++ b/src/chunknorris/parsers/markdown/markdown_parser.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 import re
+from pathlib import Path
 from typing import Any
 
 import yaml

--- a/src/chunknorris/parsers/pdf/pdf_parser.py
+++ b/src/chunknorris/parsers/pdf/pdf_parser.py
@@ -1,7 +1,6 @@
 import os
 from collections import Counter, defaultdict
 from itertools import groupby
-
 from pathlib import Path
 from typing import Any, Literal
 

--- a/src/chunknorris/parsers/pdf/pdf_parser.py
+++ b/src/chunknorris/parsers/pdf/pdf_parser.py
@@ -64,7 +64,7 @@ class PdfParser(
         body_line_spacing: float | None = None,
         enable_ml_features: bool = False,
     ) -> None:
-        """Initializes a pdf parser.
+        """Initializes a PDF parser.
 
         Args:
             extract_tables (bool, optional): whether or not tables should be extracted.

--- a/src/chunknorris/parsers/pdf/pdf_parser.py
+++ b/src/chunknorris/parsers/pdf/pdf_parser.py
@@ -18,6 +18,7 @@ from .tools import (
     DocSpecsExtraction,
     PdfExport,
     PdfLinkExtraction,
+    PdfPageClassification,
     PdfParserState,
     PdfPlotter,
     PdfTableExtraction,
@@ -30,6 +31,7 @@ from .tools import (
 
 
 class PdfParser(
+    PdfPageClassification,
     PdfLinkExtraction,
     PdfTableExtraction,
     PdfTocExtraction,
@@ -61,6 +63,7 @@ class PdfParser(
         use_ocr: Literal["always", "auto", "never"] = "auto",
         ocr_language: str = "fra+eng",
         body_line_spacing: float | None = None,
+        enable_ml_features: bool = False,
     ) -> None:
         """Initializes a pdf parser.
 
@@ -82,6 +85,11 @@ class PdfParser(
                 Tweak this parameter for better merging of lines into blocks.
             table_finder (TableFinder | None, optional): the table finder to use for parsing the tables.
                 If None, defauts to a TableFinder with default parameters.
+            enable_ml_features (bool, optional): if True, loads the ML page classifier on startup
+                so that :meth:`classify_pages` and :meth:`get_pages_to_embed` are available.
+                Requires ``onnxruntime`` or ``openvino`` and ``huggingface-hub``.
+                Use :func:`chunknorris.ml.set_ml_backend` to select the inference backend.
+                Defaults to False.
         """
         super().__init__()
         self.add_headers = add_headers
@@ -93,6 +101,9 @@ class PdfParser(
             body_line_spacing  # preserved for cleanup reset
         )
         self.table_finder = table_finder
+        self._ml_enabled = enable_ml_features
+        if enable_ml_features:
+            self._load_page_classifier()
 
         if self.use_ocr != "never":
             self.check_ocr_config_is_valid()
@@ -146,8 +157,7 @@ class PdfParser(
         Args:
             filepath_or_stream (str | bytes): Filepath to a pdf file, or byte stream.
         """
-        if isinstance(self._document, pymupdf.Document):
-            self._document.close()
+        self.cleanup_memory()
 
         if isinstance(filepath_or_stream, str):
             self.filepath = filepath_or_stream
@@ -406,12 +416,10 @@ class PdfParser(
         )
         for span in spans_to_merge:
             page_orientation_counts[span.page][span.orientation] += 1
-        print(page_orientation_counts)
         page_dominant_orientation: dict[int, tuple[float, float]] = {
             page: counts.most_common(1)[0][0]
             for page, counts in page_orientation_counts.items()
         }
-        print(page_dominant_orientation)
         spans_to_merge = [
             span
             for span in spans_to_merge
@@ -529,9 +537,9 @@ class PdfParser(
 
     def cleanup_memory(self) -> None:
         """Cleans up memory by reseting all objects created to parse the document."""
-        if self._document is not None:
+        if isinstance(self._document, pymupdf.Document):
             self._document.close()
-            self._document = None
+        self._document = None
         self.filepath = None
         self.page_start = 0
         self.page_end = None
@@ -546,3 +554,6 @@ class PdfParser(
         self.main_body_is_bold = False
         # restore the user-configured value; auto-detected value is no longer valid
         self.body_line_spacing = self._configured_body_line_spacing
+        # release cached page images — the PIL objects can be large
+        self._page_images = None
+        self._page_images_resolution = 100

--- a/src/chunknorris/parsers/pdf/tools/__init__.py
+++ b/src/chunknorris/parsers/pdf/tools/__init__.py
@@ -1,8 +1,10 @@
 from .components import Link, TextBlock, TextLine, TextSpan
+from .components_ml import PdfPageSnapshot
 from .components_tables import Cell, PdfTable, TableFinder
 from .export import PdfExport
 from .extract_links import PdfLinkExtraction
 from .extract_tables import PdfTableExtraction
 from .extract_toc import PdfTocExtraction
+from .page_classification import PdfPageClassification
 from .plot import PdfPlotter
 from .utils import DocSpecsExtraction, PdfParserState

--- a/src/chunknorris/parsers/pdf/tools/components_ml.py
+++ b/src/chunknorris/parsers/pdf/tools/components_ml.py
@@ -1,0 +1,58 @@
+"""ML-related components for the PDF parser."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from ....ml.pdf_page_classifiers.types import PdfPagePrediction
+
+if TYPE_CHECKING:
+    from PIL import Image
+
+
+@dataclass
+class PdfPageSnapshot:
+    """A rendered snapshot of a single PDF page, optionally annotated with
+    classifier predictions.
+
+    Images are stored by reference — they point to the same ``PIL.Image``
+    objects cached in ``PdfParser._page_images``, so holding a list of
+    snapshots does not duplicate memory.
+
+    Attributes:
+        page_number: Zero-based page index within the source document.
+        image: The rendered PIL image for this page.
+        predictions: Raw output dict from the page classifier, or ``None``
+            if :meth:`PdfParser.classify_pages` has not been called yet.
+    """
+
+    page_number: int
+    image: Image.Image
+    predictions: PdfPagePrediction | None = None
+
+    @property
+    def needs_image_embedding(self) -> bool:
+        """Whether this page requires a visual (image) embedding.
+
+        Raises:
+            RuntimeError: If predictions have not been computed yet.
+        """
+        if self.predictions is None:
+            raise RuntimeError(
+                "Predictions not computed yet. Call classify_pages() first."
+            )
+        return bool(self.predictions.needs_image_embedding)
+
+    @property
+    def predicted_classes(self) -> list[str]:
+        """List of predicted class labels for this page.
+
+        Raises:
+            RuntimeError: If predictions have not been computed yet.
+        """
+        if self.predictions is None:
+            raise RuntimeError(
+                "Predictions not computed yet. Call classify_pages() first."
+            )
+        return list(self.predictions.predicted_classes)

--- a/src/chunknorris/parsers/pdf/tools/components_tables.py
+++ b/src/chunknorris/parsers/pdf/tools/components_tables.py
@@ -8,8 +8,8 @@ import numpy.typing as npt
 import pandas as pd
 import pymupdf  # type: ignore | No stubs
 
-from .components import TextSpan
 from ....core.logger import LOGGER
+from .components import TextSpan
 
 
 class Cell(pymupdf.Rect):

--- a/src/chunknorris/parsers/pdf/tools/page_classification.py
+++ b/src/chunknorris/parsers/pdf/tools/page_classification.py
@@ -23,6 +23,9 @@ from .utils import PdfParserState
 if TYPE_CHECKING:
     from PIL.Image import Image as PILImage
 
+    from ....ml.pdf_page_classifiers.classifier_onnx import PDFPageClassifierONNX
+    from ....ml.pdf_page_classifiers.classifier_ov import PDFPageClassifierOV
+
 
 class PdfPageClassification(PdfParserState):
     """Mixin that adds ML-based page classification to the PDF parser.
@@ -38,7 +41,7 @@ class PdfPageClassification(PdfParserState):
     instructions rather than silently returning empty results.
     """
 
-    _page_classifier: Any | None = None
+    _page_classifier: PDFPageClassifierOV | PDFPageClassifierONNX | None = None
     _ml_enabled: bool = False
 
     def _load_page_classifier(self) -> None:

--- a/src/chunknorris/parsers/pdf/tools/page_classification.py
+++ b/src/chunknorris/parsers/pdf/tools/page_classification.py
@@ -1,0 +1,118 @@
+"""PDF page classification mixin.
+
+Provides ML-based page classification as a composable mixin following the
+same pattern as PdfTableExtraction, PdfLinkExtraction, etc.
+
+Intended usage::
+
+    parser = PdfParser(enable_ml_features=True)
+    parser.parse_file("report.pdf")
+
+    snapshots = parser.classify_pages()          # all parsed pages
+    to_embed  = parser.get_pages_to_embed()      # pages needing image embedding
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from ....decorators.decorators import timeit
+
+from .components_ml import PdfPageSnapshot
+from .utils import PdfParserState
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage
+
+
+class PdfPageClassification(PdfParserState):
+    """Mixin that adds ML-based page classification to the PDF parser.
+
+    Follows the same composition pattern as the other parser mixins: inherits
+    from :class:`PdfParserState` for shared document state, and relies on
+    :meth:`get_pages_as_images` provided by ``PdfPlotter`` being present in
+    the final MRO (guaranteed when composed into ``PdfParser``).
+
+    The classifier is loaded lazily when ``enable_ml_features=True`` is passed
+    to :class:`PdfParser`.  If ML features are disabled, calling
+    :meth:`classify_pages` raises a clear :exc:`RuntimeError` with install
+    instructions rather than silently returning empty results.
+    """
+
+    _page_classifier: Any | None = None
+    _ml_enabled: bool = False
+
+    def _load_page_classifier(self) -> None:
+        """Load the classifier using the global backend preference.
+
+        Called once during ``PdfParser.__init__`` when
+        ``enable_ml_features=True``.  Raises :exc:`ImportError` immediately if
+        the required inference backend is not installed.
+        """
+        from ....ml import get_ml_backend
+        from ....ml.pdf_page_classifiers import load_classifier
+
+        self._page_classifier = load_classifier(backend=get_ml_backend())
+
+    @timeit
+    def classify_pages(
+        self,
+        images: list[PILImage] | None = None,
+        batch_size: int = 32,
+    ) -> list[PdfPageSnapshot]:
+        """Classify all parsed PDF pages and return annotated snapshots.
+
+        On the first call without *images*, pages are rendered and stored in
+        ``self._page_images``.  The snapshots reference those cached objects
+        directly, so no image data is duplicated in memory.
+
+        Args:
+            images: Pre-rendered page images to classify.  When ``None``,
+                :meth:`get_pages_as_images` is called automatically to render
+                and cache all pages in the parsed range.
+            batch_size: Number of images per inference batch passed to the
+                classifier.  Increase for faster throughput on GPU; decrease
+                to reduce peak memory.
+
+        Returns:
+            A list of :class:`PdfPageSnapshot` objects, one per page, in
+            page order.
+
+        Raises:
+            RuntimeError: If ML features were not enabled at initialisation.
+        """
+        if not self._ml_enabled or self._page_classifier is None:
+            raise RuntimeError(
+                "ML features are disabled.\n"
+                "Initialise the parser with: PdfParser(enable_ml_features=True)\n"
+                "Required packages: pip install chunknorris[ml-onnx]  "
+                "or  pip install chunknorris[ml-openvino]"
+            )
+
+        if images is None:
+            images = self.get_pages_as_images()  # type: ignore[attr-defined]  # provided by PdfPlotter
+
+        predictions: list[dict[str, Any]] = self._page_classifier.predict(
+            images, batch_size=batch_size
+        )
+
+        return [
+            PdfPageSnapshot(
+                page_number=self.page_start + i,  # offset if page_start != 0
+                image=img,
+                predictions=pred,
+            )
+            for i, (img, pred) in enumerate(zip(images, predictions))
+        ]
+
+    def get_images_of_pages_to_embed(self) -> list[PdfPageSnapshot]:
+        """Return only the images of the pages that require a visual (image) embedding.
+
+        Returns:
+            Filtered list of :class:`PdfPageSnapshot` where
+            ``needs_image_embedding`` is ``True``.
+
+        Raises:
+            RuntimeError: If ML features were not enabled at initialisation.
+        """
+        return [s.image for s in self.classify_pages() if s.needs_image_embedding]

--- a/src/chunknorris/parsers/pdf/tools/page_classification.py
+++ b/src/chunknorris/parsers/pdf/tools/page_classification.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from ....decorators.decorators import timeit
-
 from .components_ml import PdfPageSnapshot
 from .utils import PdfParserState
 
@@ -49,6 +48,7 @@ class PdfPageClassification(PdfParserState):
         ``enable_ml_features=True``.  Raises :exc:`ImportError` immediately if
         the required inference backend is not installed.
         """
+        # pylint: disable=import-outside-toplevel
         from ....ml import get_ml_backend
         from ....ml.pdf_page_classifiers import load_classifier
 

--- a/src/chunknorris/parsers/pdf/tools/page_classification.py
+++ b/src/chunknorris/parsers/pdf/tools/page_classification.py
@@ -105,12 +105,11 @@ class PdfPageClassification(PdfParserState):
             for i, (img, pred) in enumerate(zip(images, predictions))
         ]
 
-    def get_images_of_pages_to_embed(self) -> list[PdfPageSnapshot]:
+    def get_images_of_pages_to_embed(self) -> list[PILImage]:
         """Return only the images of the pages that require a visual (image) embedding.
 
         Returns:
-            Filtered list of :class:`PdfPageSnapshot` where
-            ``needs_image_embedding`` is ``True``.
+            Filtered list of PIL.Image for which the model predicted ``needs_image_embedding`` is ``True``.
 
         Raises:
             RuntimeError: If ML features were not enabled at initialisation.

--- a/src/chunknorris/parsers/pdf/tools/plot.py
+++ b/src/chunknorris/parsers/pdf/tools/plot.py
@@ -3,9 +3,9 @@ from itertools import groupby
 from typing import Any, Literal
 
 import matplotlib.pyplot as plt
-from PIL import Image
 import numpy as np
 import pymupdf  # type: ignore : not stubs
+from PIL import Image
 
 from .components import TextBlock, TextLine, TextSpan
 from .extract_tables import PdfTable
@@ -322,10 +322,7 @@ class PdfPlotter(PdfParserState):
             otherwise a list of images.
         """
         if page_numbers is None:
-            if (
-                self._page_images is None
-                or self._page_images_resolution != resolution
-            ):
+            if self._page_images is None or self._page_images_resolution != resolution:
                 indices = list(range(self.page_start, self.page_end or self.document.page_count))  # type: ignore
                 self._page_images = [self._render_page(n, resolution) for n in indices]
                 self._page_images_resolution = resolution

--- a/src/chunknorris/parsers/pdf/tools/plot.py
+++ b/src/chunknorris/parsers/pdf/tools/plot.py
@@ -302,21 +302,42 @@ class PdfPlotter(PdfParserState):
     def get_pages_as_images(
         self, page_numbers: int | list[int] | None = None, resolution: int = 100
     ) -> Image.Image | list[Image.Image]:
-        """Get the images of the specified pages from PDF.
+        """Get the rendered images of PDF pages.
 
-        If page_numbers is an int -> returns an Image of the page
-        If page_numbers is None -> returns images for all pages
-        else returns a list of Images for specified pages.
+        When *page_numbers* is ``None`` (default), all pages in the parsed
+        range (``page_start`` to ``page_end``) are returned and the result is
+        cached in ``self._page_images`` so that repeated calls and
+        :meth:`classify_pages` share the same objects without re-rendering or
+        duplicating memory.  Passing an explicit *page_numbers* value bypasses
+        the cache.
+
+        Args:
+            page_numbers: A single page index (returns a single ``Image``), a
+                list of page indices, or ``None`` to get all parsed pages.
+            resolution: Rendering resolution in DPI.  Changing the resolution
+                invalidates the cache.
+
+        Returns:
+            A single ``PIL.Image.Image`` when *page_numbers* is an ``int``,
+            otherwise a list of images.
         """
+        if page_numbers is None:
+            if (
+                self._page_images is None
+                or self._page_images_resolution != resolution
+            ):
+                indices = list(range(self.page_start, self.page_end or self.document.page_count))  # type: ignore
+                self._page_images = [self._render_page(n, resolution) for n in indices]
+                self._page_images_resolution = resolution
+            return list(self._page_images)
+
         indices = (
-            [page_numbers]
-            if isinstance(page_numbers, int)
-            else list(page_numbers or range(self.document.page_count))  # type: ignore
+            [page_numbers] if isinstance(page_numbers, int) else list(page_numbers)
         )
-
-        def _render(n: int) -> Image.Image:
-            pix = self.document.load_page(n).get_pixmap(dpi=resolution, alpha=False)  # type: ignore
-            return Image.frombuffer("RGB", (pix.width, pix.height), pix.samples, "raw", "RGB", 0, 1)  # type: ignore
-
-        images = [_render(n) for n in indices]
+        images = [self._render_page(n, resolution) for n in indices]
         return images[0] if isinstance(page_numbers, int) else images
+
+    def _render_page(self, page_number: int, resolution: int) -> Image.Image:
+        """Render a single PDF page to a PIL image."""
+        pix = self.document.load_page(page_number).get_pixmap(dpi=resolution, alpha=False)  # type: ignore
+        return Image.frombuffer("RGB", (pix.width, pix.height), pix.samples, "raw", "RGB", 0, 1)  # type: ignore

--- a/src/chunknorris/parsers/pdf/tools/utils.py
+++ b/src/chunknorris/parsers/pdf/tools/utils.py
@@ -1,5 +1,8 @@
 from collections import Counter
-from typing import Literal
+from typing import TYPE_CHECKING, Literal
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage
 
 import pymupdf  # type: ignore : no stubs
 
@@ -30,6 +33,11 @@ class PdfParserState:
         self.tables: list[PdfTable] = []
         self.main_body_fontsizes: list[float] = []
         self.document_fontsizes: list[float] = []
+        # Page image cache — populated lazily by get_pages_as_images().
+        # Stored here so cleanup_memory() can release them and PdfPageClassification
+        # can reference the same objects without duplication.
+        self._page_images: list[PILImage] | None = None
+        self._page_images_resolution: int = 100
 
     @property
     def document(self) -> pymupdf.Document:

--- a/src/chunknorris/parsers/pdf/tools/utils.py
+++ b/src/chunknorris/parsers/pdf/tools/utils.py
@@ -1,14 +1,14 @@
 from collections import Counter
 from typing import TYPE_CHECKING, Literal
 
-if TYPE_CHECKING:
-    from PIL.Image import Image as PILImage
-
 import pymupdf  # type: ignore : no stubs
 
 from ....exceptions.exceptions import PdfParserException
 from .components import TextBlock, TextLine, TextSpan
 from .components_tables import PdfTable, TableFinder
+
+if TYPE_CHECKING:
+    from PIL.Image import Image as PILImage
 
 
 class PdfParserState:

--- a/tests/chunknorris/chunkers/test_markdown_chunker.py
+++ b/tests/chunknorris/chunkers/test_markdown_chunker.py
@@ -1,4 +1,5 @@
 import tiktoken
+
 from chunknorris.chunkers import MarkdownChunker
 from chunknorris.core.components import Chunk, MarkdownDoc
 

--- a/tests/chunknorris/parsers/test_pdf_parser.py
+++ b/tests/chunknorris/parsers/test_pdf_parser.py
@@ -1,8 +1,12 @@
 import re
 
 import pymupdf  # type: ignore -> no stubs
+from PIL.Image import Image as PILImage
 
+from chunknorris import set_ml_backend
 from chunknorris.core.components import MarkdownDoc
+from chunknorris.ml.pdf_page_classifiers.classifier_onnx import PDFPageClassifierONNX
+from chunknorris.ml.pdf_page_classifiers.classifier_ov import PDFPageClassifierOV
 from chunknorris.parsers import PdfParser
 
 
@@ -48,3 +52,34 @@ def test_parse_string(pdf_parser: PdfParser, pdf_filepath: str):
     byte_string = pymupdf.open(pdf_filepath).tobytes()  # type: ignore -> missing typing : pymupdf.open() -> pymupdf.Document
     md_string = pdf_parser.parse_string(byte_string)
     assert isinstance(md_string, MarkdownDoc)
+
+
+def test_get_pages_as_images(pdf_parser: PdfParser, pdf_filepath: str):
+    pdf_parser.read_file(pdf_filepath)
+
+    all_img = pdf_parser.get_pages_as_images(page_numbers=None)
+    img_page_5 = pdf_parser.get_pages_as_images(page_numbers=5)
+    img_page_567 = pdf_parser.get_pages_as_images(page_numbers=[5, 6, 7])
+    assert isinstance(img_page_5, PILImage)
+    assert isinstance(all_img, list)
+    assert isinstance(img_page_567, list)
+    assert len(all_img) == pdf_parser.document.page_count  # type: ignore
+    assert len(img_page_567) == 3
+    # assert the indexes of page work fine
+    assert all_img[5] == img_page_5 == img_page_567[0]
+
+
+def test_set_ml_backend():
+    set_ml_backend("openvino")
+    parser = PdfParser(enable_ml_features=True)
+    isinstance(parser._page_classifier, PDFPageClassifierOV)
+    set_ml_backend("onnx")
+    parser = PdfParser(enable_ml_features=True)
+    isinstance(parser._page_classifier, PDFPageClassifierONNX)
+
+
+def test_classify_pages(pdf_filepath: str):
+    parser = PdfParser(enable_ml_features=True)
+    parser.read_file(pdf_filepath)
+    preds = parser.classify_pages()
+    assert len(preds) == parser.document.page_count  # type: ignore

--- a/tests/test_scripts/test_on_all_files.py
+++ b/tests/test_scripts/test_on_all_files.py
@@ -3,11 +3,11 @@ from argparse import ArgumentParser
 
 from tqdm import tqdm
 
+from src.chunknorris import set_log_level
 from src.chunknorris.chunkers import MarkdownChunker
 from src.chunknorris.exceptions import PageNotFoundException, TextNotFoundException
 from src.chunknorris.parsers import DocxParser, PdfParser
 from src.chunknorris.pipelines import BasePipeline
-from src.chunknorris import set_log_level
 
 set_log_level("warning")
 


### PR DESCRIPTION
Add ML capabilities for chunknorris : the feature enables usage of a lightweight model which makes predictions on snapshots of PDF pages, telling whether the page should be embed as an image or text, based on the visual feature of the page (charts, schemas, etc...).

- [x] Integration of the model [Wikit/pdf-pages-classifier](https://huggingface.co/Wikit/pdf-pages-classifier) to PDF parser.
- [x] Enable two backends : openvino and onnx
- [x] Add tests

#### Example usage : 

```python
parser = PdfParser(enable_ml_features=True) # downloads the model based on selected backend (openvino by default)
parser.read_file("path/to/file.pdf") # or parser.parse_file() if you want to read + parse

# Make predictions on all pages. Useful to analyze the predictions.
predictions = parser.classify_pages()

# Alternatively : directly get the snapshots of the pages the should be embed as image.
images_to_embed = parser.get_images_of_pages_to_embed()
```
